### PR TITLE
Add mailhog to test email provider

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,7 +42,14 @@ services:
             - PGPASSWORD=demopassword
         volumes:
             - ./updatedb:/updatedb
-        entrypoint:
-            psql --host=$PGHOST --username=$PGUSER --dbname=$PGDB \
-                < /updatedb/001_update_db.sql  \
-                < /updatedb/002_create_test_data.sql
+        entrypoint: /updatedb/update.sh
+
+    mailhog:
+        image: mailhog/mailhog
+        tty: true
+        ports:
+            - "1025:1025"
+            - "8025:8025"
+        volumes:
+            - ./mailhog:/home/mailhog/conf
+        entrypoint: MailHog -auth-file=/home/mailhog/conf/auth-users

--- a/mailhog/auth-users
+++ b/mailhog/auth-users
@@ -1,0 +1,1 @@
+extract:$2y$10$tAys7DhDFzWphT42o.fODeviSrR8dLZ6zY8m9rlKvyJVjXhoGKPBC

--- a/updatedb/003_system_config.sql
+++ b/updatedb/003_system_config.sql
@@ -1,0 +1,2 @@
+UPDATE system SET value = 'mailhog' WHERE key = 'smtp_server';
+UPDATE system SET value =  1025 WHERE key = 'smtp_port';

--- a/updatedb/update.sh
+++ b/updatedb/update.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+psql --host=$PGHOST --username=$PGUSER --dbname=$PGDB \
+  < /updatedb/001_update_db.sql  \
+  < /updatedb/002_create_test_data.sql \
+  < /updatedb/003_system_config.sql


### PR DESCRIPTION
Could be used to add testing/custom configs for the extract, like geoshop server parameters or smtp server config.
Useful when deploying a testing instance which will have all the stuff ready.
